### PR TITLE
chore(deps): add prop-types package and update SearchResult prop types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.0.6",
         "lucide-react": "^0.263.1",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-ga4": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.0.6",
     "lucide-react": "^0.263.1",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",
@@ -55,7 +56,7 @@
       }
     ]
   },
-"jest": {
+  "jest": {
     "transformIgnorePatterns": [
       "/node_modules/(?!react-router-dom|react-router)/",
       "^.+\\.module\\.(css|sass|scss)$"

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useState, useCallback, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
 import { cn } from "../lib/utils";
 import { Search, Plus, Filter, Share2 } from "lucide-react";
 import {
@@ -586,7 +587,7 @@ const SearchComponent = ({ language = "en" }) => {
                 {sites.map((site) => (
                   <Button
                     key={site}
-                    onClick={(e) => {
+                    onClick={() => {
                       if (isMobile()) {
                         if (isMobileSelecting) {
                           setSelectedSites((prev) =>
@@ -598,7 +599,7 @@ const SearchComponent = ({ language = "en" }) => {
                           setSelectedSites([site]);
                         }
                       } else {
-                        toggleSite(site, e);
+                        toggleSite(site);
                       }
                     }}
                     className={cn(
@@ -875,6 +876,15 @@ const SearchResult = React.memo(({ result, isNewResult }) => {
     </motion.div>
   );
 });
+
+SearchResult.propTypes = {
+  result: PropTypes.shape({
+    link: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    snippet: PropTypes.string.isRequired,
+  }).isRequired,
+  isNewResult: PropTypes.bool,
+};
 
 SearchResult.displayName = "SearchResult";
 


### PR DESCRIPTION
Added the prop-types package to enforce type checking for props in SearchResult component. This improves code reliability and maintainability.

This pull request introduces several updates to the `Search` component, focusing on improving type safety with `PropTypes`, simplifying event handlers, and updating dependencies. Below are the key changes grouped by theme:

### Dependency Updates:
* Added `prop-types` as a new dependency in `package.json` to enable runtime type checking for React components.

### Type Safety Enhancements:
* Imported `PropTypes` in `src/components/Search.js` and added `propTypes` definitions for the `SearchResult` component to enforce type safety for its props. [[1]](diffhunk://#diff-34bf2ee5dad13dab79ec88e6aad7e3eb33e16a2a22784707a0f58a05c4a33b8cR3) [[2]](diffhunk://#diff-34bf2ee5dad13dab79ec88e6aad7e3eb33e16a2a22784707a0f58a05c4a33b8cR880-R888)

### Code Simplifications:
* Simplified the `onClick` handler for the `Button` component by removing the unused `event` parameter in two places within the `SearchComponent`. [[1]](diffhunk://#diff-34bf2ee5dad13dab79ec88e6aad7e3eb33e16a2a22784707a0f58a05c4a33b8cL589-R590) [[2]](diffhunk://#diff-34bf2ee5dad13dab79ec88e6aad7e3eb33e16a2a22784707a0f58a05c4a33b8cL601-R602)